### PR TITLE
Ignore macos resource files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ results/
 testing/
 testing*
 *.pyc
+._*


### PR DESCRIPTION
Add the following pattern to .gitignore `._*` which ignores macos resources files created on FUSE mounts (sshfs)

<!--
# mskcc/loki pull request

Many thanks for contributing to mskcc/loki!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/mskcc/loki/tree/master/.github/CONTRIBUTING.md)
-->

